### PR TITLE
Fix mouse offset issue with webgl

### DIFF
--- a/src/WebGL/webglInputEvents.js
+++ b/src/WebGL/webglInputEvents.js
@@ -78,7 +78,7 @@ Viva.Graph.webglInputEvents = function (webglGraphics) {
                 };
 
             window.addEventListener('resize', updateBoundRect);
-            updateBoundRect();
+            setTimeout(updateBoundRect, 0);
 
             // mouse move inside container serves only to track mouse enter/leave events.
             root.addEventListener('mousemove',


### PR DESCRIPTION
I faced issues with mouse events when the graph container wasn't at `(0, 0)`. I found out that when `updateBoundRect` was called, it reported the `<canvas>` being at `(0, 0)` even though it wasn't. Delaying the call to the function using `setTimeout` did the trick.