### PR TITLE
Correct check for undefined variable

### DIFF
--- a/src/Utils/windowEvents.js
+++ b/src/Utils/windowEvents.js
@@ -3,7 +3,7 @@ var nullEvents = require('./nullEvents.js');
 module.exports = createDocumentEvents();
 
 function createDocumentEvents() {
-  if (typeof window === undefined) {
+  if (typeof window === 'undefined') {
     return nullEvents;
   }
 


### PR DESCRIPTION
The code was comparing the result of `typeof` with a variable named `undefined`

As typeof returns a string it should compare to `'undefined'`