### PR TITLE
Fixed dual links example on tutorial_svg

### DIFF
--- a/demos/tutorial_svg/07 - Show Dual Links.html
+++ b/demos/tutorial_svg/07 - Show Dual Links.html
@@ -4,7 +4,7 @@
     <script type="text/javascript" src='../../dist/vivagraph.js'></script>
     <script type="text/javascript">
         function main() {
-            var graph = Viva.Graph.graph(),
+            var graph = Viva.Graph.graph({multigraph: true}),
                 graphics = Viva.Graph.View.svgGraphics(),
                 renderer = Viva.Graph.View.renderer(graph, {
                     graphics: graphics


### PR DESCRIPTION
Fix SVG dual links demo according to the amendments that have been made on the multigraph option of the ngraph.graph module.