### PR TITLE
Change preciseCheck function

### DIFF
--- a/src/WebGL/webglInputEvents.js
+++ b/src/WebGL/webglInputEvents.js
@@ -104,7 +104,7 @@ function webglInputEvents(webglGraphics) {
   function preciseCheck(nodeUI, x, y) {
     if (nodeUI && nodeUI.size) {
       var pos = nodeUI.position,
-        half = nodeUI.size;
+        half = nodeUI.size/2;
 
       return pos.x - half < x && x < pos.x + half &&
         pos.y - half < y && y < pos.y + half;


### PR DESCRIPTION
The variable half should be half the node size so the hitbox on the node is correct.
(When I changed the size of the node, the hitbox was off by half the node size)