### PR TITLE
readability in svg : group nodes and links

### DIFF
--- a/src/View/svgGraphics.js
+++ b/src/View/svgGraphics.js
@@ -348,7 +348,18 @@ function svgGraphics() {
         var svgRoot = svg("svg");
 
         svgContainer = svg("g")
-              .attr("buffered-rendering", "dynamic");
+              .attr("buffered-rendering", "dynamic")
+              .attr("id", "scene");
+
+        // group nodes and links for readability of elements  
+        svgNodes = svg("g")
+                .attr("id", "nodes");
+
+        svgEdges = svg("g")
+                .attr("id", "edges");
+
+        svgContainer.appendChild(svgEdges);
+        svgContainer.appendChild(svgNodes);
 
         svgRoot.appendChild(svgContainer);
         return svgRoot;


### PR DESCRIPTION
A little edit to allow a user select nodes and links distinctly. 
Since SVG does not accept z-index, I find it useful in UI design to keep nodes labels on top of links.