### PR TITLE
fix(input): listen to standard wheel event

### DIFF
--- a/src/Input/dragndrop.js
+++ b/src/Input/dragndrop.js
@@ -130,7 +130,7 @@ function dragndrop(element) {
             }
 
             e.returnValue = false;
-            var delta,
+            var delta = e.deltaY,
                 mousePos = getMousePos(e),
                 elementOffset = findElementPosition(element),
                 relMousePos = {
@@ -138,29 +138,15 @@ function dragndrop(element) {
                     y: mousePos[1] - elementOffset[1]
                 };
 
-            if (e.wheelDelta) {
-                delta = e.wheelDelta / 360; // Chrome/Safari
-            } else {
-                delta = e.detail / -9; // Mozilla
-            }
-
             scroll(e, delta, relMousePos);
         },
 
         updateScrollEvents = function (scrollCallback) {
             if (!scroll && scrollCallback) {
                 // client is interested in scrolling. Start listening to events:
-                if (browserInfo.browser === 'webkit') {
-                    element.addEventListener('mousewheel', handleMouseWheel, false); // Chrome/Safari
-                } else {
-                    element.addEventListener('DOMMouseScroll', handleMouseWheel, false); // Others
-                }
+                element.addEventListener('wheel', handleMouseWheel, false);
             } else if (scroll && !scrollCallback) {
-                if (browserInfo.browser === 'webkit') {
-                    element.removeEventListener('mousewheel', handleMouseWheel, false); // Chrome/Safari
-                } else {
-                    element.removeEventListener('DOMMouseScroll', handleMouseWheel, false); // Others
-                }
+                element.removeEventListener('wheel', handleMouseWheel, false);
             }
 
             scroll = scrollCallback;


### PR DESCRIPTION
Use the now-standardized `wheel` event to handle zoom. This is supported by [all browsers and IE >= 9](https://caniuse.com/mdn-api_element_wheel_event).

This fixes an issue where scroll events would leak through the graph element causing the background to scroll, on Firefox with scroll amounts of less than one line. According to the [MDN docs on the `DOMMouseScroll` event](https://developer.mozilla.org/en-US/docs/Web/API/Element/DOMMouseScroll_event):

> If you want to prevent the default action of mouse wheel events, it's not enough to handle only this event on Gecko because If scroll amount by a native mouse wheel event is less than 1 line (or less than 1 page when the system setting is by page scroll), other mouse wheel events may be fired without this event.